### PR TITLE
Feature/soft delete user

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -49,6 +49,9 @@ export const loginUser = async (req: Request, res: Response) => {
   try {
     const findUser = await em.findOne(User, { email: userData.email }) as Loaded<User, never>;
     if (!findUser) return res.status(401).send({message: 'Invalid user'});
+    if (findUser.isActive === false) {
+      return res.status(403).json({ message: 'Usuario desactivado' });
+    }
     const isPasswordValid = await bcrypt.compare(userData.password, findUser.password)
 
     if (!isPasswordValid) return res.status(401).json({message: 'Credenciales inválidas'});

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -2,6 +2,8 @@ import express, { Request, Response } from 'express';
 import { User } from './user.entity.js';
 import { orm } from '../shared/db/orm.js';
 import bcrypt from 'bcrypt';
+import { Order } from '../order/order.entity.js';
+import { Product } from '../product/product.entity.js';
 
 const em = orm.em.fork();
 
@@ -80,7 +82,25 @@ async function update(req: Request, res: Response){
   }
 };
 
-async function softDeleteUser(req: Request, res: Response) {
+async function forceCancelOrder(order: Order) {
+  for (const item of order.orderItems) {
+    const product = await em.findOne(Product, { id: item.productId });
+    if (product) {
+      product.stock += item.quantity; // Devolver stock
+      await em.persistAndFlush(product);
+    }
+  }
+
+  if (order.user && order.user._id) {
+    const user = await em.findOne(User, { id: order.user._id.toString() });
+  }
+
+  order.status = 'cancelled';
+  order.updatedDate = new Date();
+  await em.persistAndFlush(order);
+}
+
+export async function softDeleteUser(req: Request, res: Response) {
   try {
     const id = req.params.id;
     const user = await em.findOne(User, { id });
@@ -89,10 +109,18 @@ async function softDeleteUser(req: Request, res: Response) {
       return res.status(404).json({ message: 'User not found' });
     }
 
+    const pendingOrders = await em.find(Order, {
+      user: user,
+      status: 'pending'
+    });
+
+    for (const order of pendingOrders) {
+      await forceCancelOrder(order);
+    }
     user.isActive = false;
     await em.persistAndFlush(user);
 
-    return res.status(200).json({ message: 'User deactivated successfully' });
+    return res.status(200).json({ message: 'User deactivated and pending orders cancelled successfully' });
   } catch (error: any) {
     return res.status(500).json({ message: 'Internal server error', error: error.message });
   }

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -41,6 +41,9 @@ export class User extends BaseEntity {
     @Property({nullable: true, unique: true})
     resetPasswordExpires?: Date
 
+    @Property({nullable: true})
+    isActive?: boolean = true; 
+
     @OneToMany(() => Order, (order) => order.user, {cascade:[Cascade.ALL]})
     orders = new Collection<Order>(this);
 

--- a/src/user/user.routes.ts
+++ b/src/user/user.routes.ts
@@ -7,7 +7,7 @@ export const userRouter = Router();
 userRouter.get('/', controller.findAll);
 userRouter.put('/update-password',onlyAnonymous, controller.updatePassword);
 userRouter.get('/by-email', controller.findUserByEmail);
-userRouter.delete('/:id', authenticateClient, controller.remove);
+userRouter.delete('/:id', authenticateClient, controller.softDeleteUser);
 userRouter.get('/:id', controller.findOne);
 userRouter.put('/:id',authenticateClient, controller.update);
 userRouter.post('/',onlyAnonymous, controller.signUp);


### PR DESCRIPTION
**Improvements**
This PR introduces logical deletion for users and adjusts the handling of related components.
Key changes:
A new field was added to the user entity to manage deletion status (isActive or similar).
When a user is "deleted", their status is set to false, but their data remains stored in the database.
Once deleted, the user is no longer able to log in.
If the deleted user has any orders in progress, those orders are automatically marked as cancelled, regardless of whether 24 hours have passed since the order was created.
Other components, such as the orders module, were updated to support this logic and ensure consistency.

**How to test it**
Go to the user management panel and delete a user.
 Confirm that the user is not removed from the database but has their active flag set to false.
All in-progress orders associated with the user are cancelled, even if they are less than 24 hours old.
Try to log in using the deleted user's credentials → Login should fail.
Confirm that the deleted user is no longer visible in user lists (of activated users) or accessible via restricted endpoints.