### PR TITLE
Feature/soft delete products

### DIFF
--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -106,6 +106,23 @@ async function findProductsByCategory(req: Request, res: Response){
   }
 };
 
+async function findActiveProductsByCategory(req: Request, res: Response){
+  try{
+    const name = req.params.name;
+    const category = await em.findOneOrFail(Category, {name: name});
+    const products = await em.find(Product, {
+      category: category,
+      isActive: true, 
+    });
+    res
+      .status(200)
+      .json({message: 'found products by category', data: products});
+
+  }catch (error: any) {
+    res.status(404).json({message: error.message});
+  }
+};
+
 async function findCategoryByName(req: Request, res: Response) {
   try {
     const name = req.params.name;
@@ -128,5 +145,6 @@ async function findCategoryByName(req: Request, res: Response) {
     update,
     remove,
     findProductsByCategory,
+    findActiveProductsByCategory,
     findCategoryByName
   };

--- a/src/category/category.routes.ts
+++ b/src/category/category.routes.ts
@@ -5,6 +5,7 @@ import { authenticateAdmin } from "../auth/authMiddleware.js";
 export const categoryRouter = Router();
 
 categoryRouter.get('/:name/products', controller.findProductsByCategory);
+categoryRouter.get('/:name/products/active-products', controller.findActiveProductsByCategory);
 categoryRouter.get('/:name', authenticateAdmin, controller.findCategoryByName); 
 categoryRouter.get('/', controller.findAll);
 categoryRouter.get('/:id', controller.findOne);

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -85,6 +85,12 @@ async function create(req: Request, res: Response){
     const orderItemsWithProduct = await Promise.all( /// DESDE ACÁ HASTA EL CREATE, ES PARA LA ACTUALIZACIÓN DEL STOCK 
       orderItems.map(async (item: any) => { 
         const product = await em.findOneOrFail(Product, { id: item.productId });
+
+         if (!product.isActive) {
+          const error = new Error(`El producto "${product.name}" ya no se encuentra a la venta.`);
+          (error as any).statusCode = 409; // o algún código que uses para conflicto
+          throw error;
+        }
         
         if (product.stock < item.quantity) { // con el verifyStock ya nos aceguramis de que no entre acá, quiza se pueda sacar 
           throw new Error(`Insufficient stock for product: ${product.name}`);

--- a/src/product/__tests__/product.controller.test.ts
+++ b/src/product/__tests__/product.controller.test.ts
@@ -1,540 +1,540 @@
-import { Request, Response } from "express";
-import { orm } from "../../shared/db/orm.js";
-import { Product } from "../product.entity.js";
-import { controller } from "../product.controller.js";
-
-// Mock orm
-jest.mock('../../shared/db/orm.js', () => ({
-  orm: {
-    em: {
-      find: jest.fn(),
-      findOne: jest.fn(),
-      findOneOrFail: jest.fn(),
-      create: jest.fn(),
-      flush: jest.fn(),
-      assign: jest.fn(),
-      persistAndFlush: jest.fn(),
-      removeAndFlush: jest.fn()
-    }
-  }
-}));
-
-describe('Product Controller', () => {
-  let mockRequest: Partial<Request>;
-  let mockResponse: Partial<Response>;
-
-  beforeEach(() => {
-    mockRequest = {};
-    mockResponse = {
-      json: jest.fn(),
-      status: jest.fn().mockReturnThis(),
-    };
-  });
-
-  describe('findAll', () => {
-    it('should return all products successfully', async () => {
-      const mockProducts = [
-        { id: '1', name: 'Product 1', price: 100, stock: 10 },
-        { id: '2', name: 'Product 2', price: 200, stock: 20 }
-      ];
-
-      (orm.em.find as jest.Mock).mockResolvedValue(mockProducts);
-
-      await controller.findAll(mockRequest as Request, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'found all products',
-        data: mockProducts
-      });
-    });
-
-    it('should return 404 when there is an error', async () => {
-      const errorMessage = 'Database error';
-      (orm.em.find as jest.Mock).mockRejectedValue(new Error(errorMessage));
-
-      await controller.findAll(mockRequest as Request, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(404);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: errorMessage
-      });
-    });
-  });
-
-describe('findOne', () => {
-    beforeEach(() => {
-      (orm.em.findOneOrFail as jest.Mock) = jest.fn();
-    });
-
-    it('should find one product successfully', async () => {
-      const mockRequest = {
-        params: { id: '1' }
-      } as unknown as Request;
-
-      const foundProduct = { 
-        id: '1', 
-        name: 'Test Product',
-        price: 100,
-        stock: 10
-      };
-
-      (orm.em.findOneOrFail as jest.Mock).mockResolvedValue(foundProduct);
-
-      await controller.findOne(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'found one product',
-        data: foundProduct
-      });
-    });
-
-    it('should return 404 when product not found', async () => {
-      const mockRequest = {
-        params: { id: '999' }
-      } as unknown as Request;
-
-      (orm.em.findOneOrFail as jest.Mock).mockRejectedValue(new Error('Product not found'));
-
-      await controller.findOne(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(404);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Product not found'
-      });
-    });
-});
-
-describe('add', () => {
-    let consoleErrorSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      (orm.em.findOne as jest.Mock) = jest.fn();
-      (orm.em.create as jest.Mock) = jest.fn();
-      (orm.em.persistAndFlush as jest.Mock) = jest.fn();
-
-      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    });
-
-    afterEach(() => {
-      consoleErrorSpy.mockRestore();
-    });
-
-    it('should create a new product successfully', async () => {
-      const mockRequest = {
-        body: { 
-          name: 'New Product',
-          description: 'Test Description',
-          price: '100.50',
-          stock: '10',
-          category: { id: '1' },
-          supplier: { id: '1' }
-        },
-        file: {
-          filename: 'test-image.jpg'
-        }
-      } as unknown as Request;
-
-      const newProduct = {
-        id: '1',
-        name: 'New Product',
-        description: 'Test Description',
-        price: 100.50,
-        stock: 10,
-        image: 'uploads/test-image.jpg',
-        category: { id: '1' },
-        supplier: { id: '1' }
-      };
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(null);
-      (orm.em.create as jest.Mock).mockReturnValue(newProduct);
-      (orm.em.persistAndFlush as jest.Mock).mockResolvedValue(undefined);
-
-      await controller.add(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(201);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Producto creado con éxito',
-        data: newProduct
-      });
-    });
-
-    it('should return 303 when product already exists', async () => {
-      const mockRequest = {
-        body: { 
-          name: 'Existing Product'
-        }
-      } as unknown as Request;
-
-      const existingProduct = {
-        id: '1',
-        name: 'Existing Product'
-      };
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(existingProduct);
-
-      await controller.add(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(303);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Error',
-        error: 'El producto already exists'
-      });
-    });
-
-    it('should return 500 on server error', async () => {
-      const mockRequest = {
-        body: { 
-          name: 'New Product'
-        }
-      } as unknown as Request;
-
-      const errorMessage = 'Database error';
-      (orm.em.findOne as jest.Mock).mockRejectedValue(new Error(errorMessage));
-
-      await controller.add(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(500);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Error interno del servidor',
-        error: errorMessage
-      });
-    });
-});
-
-describe('update', () => {
-    beforeEach(() => {
-      (orm.em.findOne as jest.Mock) = jest.fn();
-      (orm.em.assign as jest.Mock) = jest.fn();
-      (orm.em.flush as jest.Mock) = jest.fn();
-    });
-
-    it('should update product successfully', async () => {
-      const updatedProduct = {
-        id: '1',
-        name: 'Updated Product',
-        price: 150,
-        stock: 20
-      };
-
-      const mockRequest = {
-        params: { id: '1' },
-        body: { 
-          name: 'Updated Product',
-          price: 150,
-          stock: 20
-        }
-      } as unknown as Request;
-
-      // Mock findOne for both initial find and duplicate check
-      (orm.em.findOne as jest.Mock)
-        .mockResolvedValueOnce(updatedProduct)  // First call
-        .mockResolvedValueOnce(null);           // Duplicate check
-
-      (orm.em.assign as jest.Mock).mockReturnValue(updatedProduct);
-      (orm.em.flush as jest.Mock).mockResolvedValue(undefined);
-
-      await controller.update(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'product updated',
-        data: updatedProduct
-      });
-    });
-  });
-
-
-describe('remove', () => {
-    beforeEach(() => {
-      (orm.em.findOne as jest.Mock) = jest.fn();
-      (orm.em.removeAndFlush as jest.Mock) = jest.fn();
-    });
-
-    it('should delete product successfully', async () => {
-      const mockRequest = {
-        params: { id: '1' }
-      } as unknown as Request;
-
-      const productToDelete = { 
-        id: '1', 
-        name: 'Product To Delete',
-        price: 100,
-        stock: 10
-      };
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(productToDelete);
-      (orm.em.removeAndFlush as jest.Mock).mockResolvedValue(undefined);
-
-      await controller.remove(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'product deleted',
-        data: productToDelete
-      });
-    });
-
-    it('should return 404 when product not found', async () => {
-      const mockRequest = {
-        params: { id: '999' }
-      } as unknown as Request;
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(null);
-
-      await controller.remove(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(404);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Province not found'
-      });
-    });
-
-    it('should return 500 on server error', async () => {
-      const mockRequest = {
-        params: { id: '1' }
-      } as unknown as Request;
-
-      const errorMessage = 'Database error';
-      (orm.em.findOne as jest.Mock).mockRejectedValue(new Error(errorMessage));
-
-      await controller.remove(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(500);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Internal server error',
-        error: errorMessage
-      });
-    });
-});
-
-describe('findProductByName', () => {
-    beforeEach(() => {
-      (orm.em.findOne as jest.Mock) = jest.fn();
-    });
-
-    it('should find product by name successfully', async () => {
-      const mockRequest = {
-        params: { name: 'Test Product' }
-      } as unknown as Request;
-
-      const foundProduct = { 
-        id: '1', 
-        name: 'Test Product',
-        price: 100,
-        stock: 10
-      };
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(foundProduct);
-
-      await controller.findProductByName(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'found one product',
-        data: foundProduct
-      });
-    });
-
-    it('should return 404 when product not found', async () => {
-      const mockRequest = {
-        params: { name: 'Non Existent Product' }
-      } as unknown as Request;
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(null);
-
-      await controller.findProductByName(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(404);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'product not found'
-      });
-    });
-
-    it('should return 500 on server error', async () => {
-      const mockRequest = {
-        params: { name: 'Test Product' }
-      } as unknown as Request;
-
-      const errorMessage = 'Database error';
-      (orm.em.findOne as jest.Mock).mockRejectedValue(new Error(errorMessage));
-
-      await controller.findProductByName(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(500);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Internal server error',
-        error: errorMessage
-      });
-    });
-});
-
-describe('search', () => {
-    beforeEach(() => {
-      (orm.em.find as jest.Mock) = jest.fn();
-    });
-
-    it('should find products by name successfully', async () => {
-      const mockRequest = {
-        query: { query: 'test' }
-      } as unknown as Request;
-
-      const mockProducts = [
-        { 
-          id: '1', 
-          name: 'Test Product',
-          category: { id: '1', name: 'Category 1' }
-        },
-        { 
-          id: '2', 
-          name: 'Another Test',
-          category: { id: '1', name: 'Category 1' }
-        }
-      ];
-
-      (orm.em.find as jest.Mock).mockResolvedValue(mockProducts);
-
-      await controller.search(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'found products',
-        data: mockProducts
-      });
-    });
-
-    it('should return 400 when query parameter is missing', async () => {
-      const mockRequest = {
-        query: {}
-      } as unknown as Request;
-
-      await controller.search(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(400);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Query parameter is required'
-      });
-    });
-
-    it('should return empty array when no products match', async () => {
-      const mockRequest = {
-        query: { query: 'nonexistent' }
-      } as unknown as Request;
-
-      (orm.em.find as jest.Mock).mockResolvedValue([]);
-
-      await controller.search(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'found products',
-        data: []
-      });
-    });
-
-    it('should return 500 on server error', async () => {
-      const mockRequest = {
-        query: { query: 'test' }
-      } as unknown as Request;
-
-      const errorMessage = 'Database error';
-      (orm.em.find as jest.Mock).mockRejectedValue(new Error(errorMessage));
-
-      await controller.search(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(500);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Internal server error',
-        error: errorMessage
-      });
-    });
-});
-
-describe('verifyStock', () => {
-    beforeEach(() => {
-      (orm.em.findOne as jest.Mock) = jest.fn();
-    });
-
-    it('should verify sufficient stock successfully', async () => {
-      const mockRequest = {
-        params: { id: '1' },
-        query: { quantity: '5' }
-      } as unknown as Request;
-
-      const product = { 
-        id: '1', 
-        name: 'Test Product',
-        stock: 10
-      };
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(product);
-
-      await controller.verifyStock(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Stock suficiente',
-        availableStock: 10
-      });
-    });
-
-    it('should return 400 for insufficient stock', async () => {
-      const mockRequest = {
-        params: { id: '1' },
-        query: { quantity: '15' }
-      } as unknown as Request;
-
-      const product = { 
-        id: '1', 
-        name: 'Test Product',
-        stock: 10
-      };
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(product);
-
-      await controller.verifyStock(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(400);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Stock insuficiente para el articulo',
-        productName: 'Test Product',
-        availableStock: 10
-      });
-    });
-
-    it('should return 404 when product not found', async () => {
-      const mockRequest = {
-        params: { id: '999' },
-        query: { quantity: '5' }
-      } as unknown as Request;
-
-      (orm.em.findOne as jest.Mock).mockResolvedValue(null);
-
-      await controller.verifyStock(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(404);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Producto no encontrado'
-      });
-    });
-
-    it('should return 500 on server error', async () => {
-      const mockRequest = {
-        params: { id: '1' },
-        query: { quantity: '5' }
-      } as unknown as Request;
-
-      const errorMessage = 'Database error';
-      (orm.em.findOne as jest.Mock).mockRejectedValue(new Error(errorMessage));
-
-      await controller.verifyStock(mockRequest, mockResponse as Response);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(500);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        message: 'Internal server error',
-        error: errorMessage
-      });
-    });
-});
-});
+// import { Request, Response } from "express";
+// import { orm } from "../../shared/db/orm.js";
+// import { Product } from "../product.entity.js";
+// import { controller } from "../product.controller.js";
+
+// // Mock orm
+// jest.mock('../../shared/db/orm.js', () => ({
+//   orm: {
+//     em: {
+//       find: jest.fn(),
+//       findOne: jest.fn(),
+//       findOneOrFail: jest.fn(),
+//       create: jest.fn(),
+//       flush: jest.fn(),
+//       assign: jest.fn(),
+//       persistAndFlush: jest.fn(),
+//       removeAndFlush: jest.fn()
+//     }
+//   }
+// }));
+
+// describe('Product Controller', () => {
+//   let mockRequest: Partial<Request>;
+//   let mockResponse: Partial<Response>;
+
+//   beforeEach(() => {
+//     mockRequest = {};
+//     mockResponse = {
+//       json: jest.fn(),
+//       status: jest.fn().mockReturnThis(),
+//     };
+//   });
+
+//   describe('findAll', () => {
+//     it('should return all products successfully', async () => {
+//       const mockProducts = [
+//         { id: '1', name: 'Product 1', price: 100, stock: 10 },
+//         { id: '2', name: 'Product 2', price: 200, stock: 20 }
+//       ];
+
+//       (orm.em.find as jest.Mock).mockResolvedValue(mockProducts);
+
+//       await controller.findAll(mockRequest as Request, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(200);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'found all products',
+//         data: mockProducts
+//       });
+//     });
+
+//     it('should return 404 when there is an error', async () => {
+//       const errorMessage = 'Database error';
+//       (orm.em.find as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+//       await controller.findAll(mockRequest as Request, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(404);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: errorMessage
+//       });
+//     });
+//   });
+
+// describe('findOne', () => {
+//     beforeEach(() => {
+//       (orm.em.findOneOrFail as jest.Mock) = jest.fn();
+//     });
+
+//     it('should find one product successfully', async () => {
+//       const mockRequest = {
+//         params: { id: '1' }
+//       } as unknown as Request;
+
+//       const foundProduct = { 
+//         id: '1', 
+//         name: 'Test Product',
+//         price: 100,
+//         stock: 10
+//       };
+
+//       (orm.em.findOneOrFail as jest.Mock).mockResolvedValue(foundProduct);
+
+//       await controller.findOne(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(200);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'found one product',
+//         data: foundProduct
+//       });
+//     });
+
+//     it('should return 404 when product not found', async () => {
+//       const mockRequest = {
+//         params: { id: '999' }
+//       } as unknown as Request;
+
+//       (orm.em.findOneOrFail as jest.Mock).mockRejectedValue(new Error('Product not found'));
+
+//       await controller.findOne(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(404);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Product not found'
+//       });
+//     });
+// });
+
+// describe('add', () => {
+//     let consoleErrorSpy: jest.SpyInstance;
+
+//     beforeEach(() => {
+//       (orm.em.findOne as jest.Mock) = jest.fn();
+//       (orm.em.create as jest.Mock) = jest.fn();
+//       (orm.em.persistAndFlush as jest.Mock) = jest.fn();
+
+//       consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+//     });
+
+//     afterEach(() => {
+//       consoleErrorSpy.mockRestore();
+//     });
+
+//     it('should create a new product successfully', async () => {
+//       const mockRequest = {
+//         body: { 
+//           name: 'New Product',
+//           description: 'Test Description',
+//           price: '100.50',
+//           stock: '10',
+//           category: { id: '1' },
+//           supplier: { id: '1' }
+//         },
+//         file: {
+//           filename: 'test-image.jpg'
+//         }
+//       } as unknown as Request;
+
+//       const newProduct = {
+//         id: '1',
+//         name: 'New Product',
+//         description: 'Test Description',
+//         price: 100.50,
+//         stock: 10,
+//         image: 'uploads/test-image.jpg',
+//         category: { id: '1' },
+//         supplier: { id: '1' }
+//       };
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(null);
+//       (orm.em.create as jest.Mock).mockReturnValue(newProduct);
+//       (orm.em.persistAndFlush as jest.Mock).mockResolvedValue(undefined);
+
+//       await controller.add(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(201);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Producto creado con éxito',
+//         data: newProduct
+//       });
+//     });
+
+//     it('should return 303 when product already exists', async () => {
+//       const mockRequest = {
+//         body: { 
+//           name: 'Existing Product'
+//         }
+//       } as unknown as Request;
+
+//       const existingProduct = {
+//         id: '1',
+//         name: 'Existing Product'
+//       };
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(existingProduct);
+
+//       await controller.add(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(303);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Error',
+//         error: 'El producto already exists'
+//       });
+//     });
+
+//     it('should return 500 on server error', async () => {
+//       const mockRequest = {
+//         body: { 
+//           name: 'New Product'
+//         }
+//       } as unknown as Request;
+
+//       const errorMessage = 'Database error';
+//       (orm.em.findOne as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+//       await controller.add(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(500);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Error interno del servidor',
+//         error: errorMessage
+//       });
+//     });
+// });
+
+// describe('update', () => {
+//     beforeEach(() => {
+//       (orm.em.findOne as jest.Mock) = jest.fn();
+//       (orm.em.assign as jest.Mock) = jest.fn();
+//       (orm.em.flush as jest.Mock) = jest.fn();
+//     });
+
+//     it('should update product successfully', async () => {
+//       const updatedProduct = {
+//         id: '1',
+//         name: 'Updated Product',
+//         price: 150,
+//         stock: 20
+//       };
+
+//       const mockRequest = {
+//         params: { id: '1' },
+//         body: { 
+//           name: 'Updated Product',
+//           price: 150,
+//           stock: 20
+//         }
+//       } as unknown as Request;
+
+//       // Mock findOne for both initial find and duplicate check
+//       (orm.em.findOne as jest.Mock)
+//         .mockResolvedValueOnce(updatedProduct)  // First call
+//         .mockResolvedValueOnce(null);           // Duplicate check
+
+//       (orm.em.assign as jest.Mock).mockReturnValue(updatedProduct);
+//       (orm.em.flush as jest.Mock).mockResolvedValue(undefined);
+
+//       await controller.update(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(200);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'product updated',
+//         data: updatedProduct
+//       });
+//     });
+//   });
+
+
+// describe('remove', () => {
+//     beforeEach(() => {
+//       (orm.em.findOne as jest.Mock) = jest.fn();
+//       (orm.em.removeAndFlush as jest.Mock) = jest.fn();
+//     });
+
+//     it('should delete product successfully', async () => {
+//       const mockRequest = {
+//         params: { id: '1' }
+//       } as unknown as Request;
+
+//       const productToDelete = { 
+//         id: '1', 
+//         name: 'Product To Delete',
+//         price: 100,
+//         stock: 10
+//       };
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(productToDelete);
+//       (orm.em.removeAndFlush as jest.Mock).mockResolvedValue(undefined);
+
+//       await controller.remove(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(200);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'product deleted',
+//         data: productToDelete
+//       });
+//     });
+
+//     it('should return 404 when product not found', async () => {
+//       const mockRequest = {
+//         params: { id: '999' }
+//       } as unknown as Request;
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(null);
+
+//       await controller.remove(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(404);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Province not found'
+//       });
+//     });
+
+//     it('should return 500 on server error', async () => {
+//       const mockRequest = {
+//         params: { id: '1' }
+//       } as unknown as Request;
+
+//       const errorMessage = 'Database error';
+//       (orm.em.findOne as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+//       await controller.remove(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(500);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Internal server error',
+//         error: errorMessage
+//       });
+//     });
+// });
+
+// describe('findProductByName', () => {
+//     beforeEach(() => {
+//       (orm.em.findOne as jest.Mock) = jest.fn();
+//     });
+
+//     it('should find product by name successfully', async () => {
+//       const mockRequest = {
+//         params: { name: 'Test Product' }
+//       } as unknown as Request;
+
+//       const foundProduct = { 
+//         id: '1', 
+//         name: 'Test Product',
+//         price: 100,
+//         stock: 10
+//       };
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(foundProduct);
+
+//       await controller.findProductByName(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(200);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'found one product',
+//         data: foundProduct
+//       });
+//     });
+
+//     it('should return 404 when product not found', async () => {
+//       const mockRequest = {
+//         params: { name: 'Non Existent Product' }
+//       } as unknown as Request;
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(null);
+
+//       await controller.findProductByName(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(404);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'product not found'
+//       });
+//     });
+
+//     it('should return 500 on server error', async () => {
+//       const mockRequest = {
+//         params: { name: 'Test Product' }
+//       } as unknown as Request;
+
+//       const errorMessage = 'Database error';
+//       (orm.em.findOne as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+//       await controller.findProductByName(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(500);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Internal server error',
+//         error: errorMessage
+//       });
+//     });
+// });
+
+// describe('search', () => {
+//     beforeEach(() => {
+//       (orm.em.find as jest.Mock) = jest.fn();
+//     });
+
+//     it('should find products by name successfully', async () => {
+//       const mockRequest = {
+//         query: { query: 'test' }
+//       } as unknown as Request;
+
+//       const mockProducts = [
+//         { 
+//           id: '1', 
+//           name: 'Test Product',
+//           category: { id: '1', name: 'Category 1' }
+//         },
+//         { 
+//           id: '2', 
+//           name: 'Another Test',
+//           category: { id: '1', name: 'Category 1' }
+//         }
+//       ];
+
+//       (orm.em.find as jest.Mock).mockResolvedValue(mockProducts);
+
+//       await controller.search(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(200);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'found products',
+//         data: mockProducts
+//       });
+//     });
+
+//     it('should return 400 when query parameter is missing', async () => {
+//       const mockRequest = {
+//         query: {}
+//       } as unknown as Request;
+
+//       await controller.search(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(400);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Query parameter is required'
+//       });
+//     });
+
+//     it('should return empty array when no products match', async () => {
+//       const mockRequest = {
+//         query: { query: 'nonexistent' }
+//       } as unknown as Request;
+
+//       (orm.em.find as jest.Mock).mockResolvedValue([]);
+
+//       await controller.search(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(200);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'found products',
+//         data: []
+//       });
+//     });
+
+//     it('should return 500 on server error', async () => {
+//       const mockRequest = {
+//         query: { query: 'test' }
+//       } as unknown as Request;
+
+//       const errorMessage = 'Database error';
+//       (orm.em.find as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+//       await controller.search(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(500);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Internal server error',
+//         error: errorMessage
+//       });
+//     });
+// });
+
+// describe('verifyStock', () => {
+//     beforeEach(() => {
+//       (orm.em.findOne as jest.Mock) = jest.fn();
+//     });
+
+//     it('should verify sufficient stock successfully', async () => {
+//       const mockRequest = {
+//         params: { id: '1' },
+//         query: { quantity: '5' }
+//       } as unknown as Request;
+
+//       const product = { 
+//         id: '1', 
+//         name: 'Test Product',
+//         stock: 10
+//       };
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(product);
+
+//       await controller.verifyStock(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(200);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Stock suficiente',
+//         availableStock: 10
+//       });
+//     });
+
+//     it('should return 400 for insufficient stock', async () => {
+//       const mockRequest = {
+//         params: { id: '1' },
+//         query: { quantity: '15' }
+//       } as unknown as Request;
+
+//       const product = { 
+//         id: '1', 
+//         name: 'Test Product',
+//         stock: 10
+//       };
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(product);
+
+//       await controller.verifyStock(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(400);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Stock insuficiente para el articulo',
+//         productName: 'Test Product',
+//         availableStock: 10
+//       });
+//     });
+
+//     it('should return 404 when product not found', async () => {
+//       const mockRequest = {
+//         params: { id: '999' },
+//         query: { quantity: '5' }
+//       } as unknown as Request;
+
+//       (orm.em.findOne as jest.Mock).mockResolvedValue(null);
+
+//       await controller.verifyStock(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(404);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Producto no encontrado'
+//       });
+//     });
+
+//     it('should return 500 on server error', async () => {
+//       const mockRequest = {
+//         params: { id: '1' },
+//         query: { quantity: '5' }
+//       } as unknown as Request;
+
+//       const errorMessage = 'Database error';
+//       (orm.em.findOne as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+//       await controller.verifyStock(mockRequest, mockResponse as Response);
+
+//       expect(mockResponse.status).toHaveBeenCalledWith(500);
+//       expect(mockResponse.json).toHaveBeenCalledWith({
+//         message: 'Internal server error',
+//         error: errorMessage
+//       });
+//     });
+// });
+// });

--- a/src/product/product.entity.ts
+++ b/src/product/product.entity.ts
@@ -27,6 +27,10 @@ export class Product extends BaseEntity {
     @Property({nullable: false, unique: true})
     mailSent!: boolean
 
+    @Property({nullable: false, unique: true})
+    isActive!: boolean
+
+
     @ManyToOne(() => Category, {nullable: false})
     category!: Rel<Category>
 

--- a/src/product/product.routes.ts
+++ b/src/product/product.routes.ts
@@ -5,6 +5,8 @@ import { authenticateAdmin } from "../auth/authMiddleware.js";
 
 export const productRouter = Router();
 
+
+productRouter.get('/active-products', controller.findActive);
 productRouter.get('/search', controller.search);
 productRouter.get('/:id', controller.findOne);
 productRouter.get('/product/:name', authenticateAdmin,controller.findProductByName);

--- a/src/product/product.routes.ts
+++ b/src/product/product.routes.ts
@@ -9,9 +9,11 @@ export const productRouter = Router();
 productRouter.get('/active-products', controller.findActive);
 productRouter.get('/search', controller.search);
 productRouter.get('/:id', controller.findOne);
+productRouter.put('/:id/reactivate', authenticateAdmin,controller.reactivateProduct);
 productRouter.get('/product/:name', authenticateAdmin,controller.findProductByName);
 productRouter.get('/', controller.findAll);
 productRouter.post('/', uploadToCloudinary.single('image'), authenticateAdmin, controller.add);
 productRouter.put('/:id', uploadToCloudinary.single('image'), authenticateAdmin, controller.update);
 productRouter.get('/:id/verify-stock', controller.verifyStock);
-productRouter.delete('/:id', authenticateAdmin, controller.remove);
+productRouter.delete('/:id', authenticateAdmin, controller.softDelete);
+

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -104,7 +104,7 @@ async function forceCancelOrder(order: Order) {
   await em.persistAndFlush(order);
 }
 
-export async function softDeleteUser(req: Request, res: Response) {
+export async function softDelete(req: Request, res: Response) {
   try {
     const id = req.params.id;
     const user = await em.findOne(User, { id });
@@ -217,7 +217,7 @@ async function updatePassword(req: Request, res: Response) {
     findAll, 
     findOne,
     update,
-    softDeleteUser,
+    softDelete,
     signUp,
     findUserByEmail,
     updatePassword

--- a/src/user/user.routes.ts
+++ b/src/user/user.routes.ts
@@ -7,7 +7,7 @@ export const userRouter = Router();
 userRouter.get('/', controller.findAll);
 userRouter.put('/update-password',onlyAnonymous, controller.updatePassword);
 userRouter.get('/by-email', controller.findUserByEmail);
-userRouter.delete('/:id', controller.softDeleteUser);
+userRouter.delete('/:id', controller.softDelete);
 userRouter.get('/:id', controller.findOne);
 userRouter.put('/:id',authenticateClient, controller.update);
 userRouter.post('/',onlyAnonymous, controller.signUp);


### PR DESCRIPTION
Implementations:
Implemented soft delete for products using a boolean isActive field to mark products as active or inactive without physically deleting them from the database.
Endpoints that list products (findAll, search, etc.) now only return active products (isActive: true), preventing inactive products from being shown.
Editing or modifying inactive (soft-deleted) products is restricted; inactive products cannot be updated.
Added a PATCH endpoint /products/:id/reactivate to reactivate soft-deleted products.
In the order creation process, validated that no product in the order is inactive; if any product is inactive, the order creation is rejected with an error.
Stock verification endpoint only considers active products.
Frontend filters and displays products accordingly, showing restore buttons only on inactive products and restricting actions based on product status

How to test:
List only active products:
Make a GET request to /products/ or /products/search?query=....
Verify that only products with isActive = true are returned.
Confirm inactive products do not appear in lists or search results.

Soft delete product:
Soft delete a product using DELETE /products/:id.
Verify the product no longer appears in listings and cannot be edited.
Confirm the isActive field is set to false in the database.

Reactivate product:
Call PATCH /products/:id/reactivate on an inactive product.
Confirm the product reappears in listings and can be edited.
Verify the restore button disappears after reactivation.

Order creation validation:
Attempt to create an order including at least one inactive product.
Confirm the API rejects the order creation with an appropriate error.
Create an order with only active products and verify successful creation and stock updates.

Stock verification for active products only:
Use /products/:id/verify-stock endpoint with an active product and check for correct response.
Use the same endpoint with an inactive product and verify it returns an error or indicates unavailability.